### PR TITLE
Added DirectSound3D to the graveyard

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -596,8 +596,11 @@
   {
     "dateClose": "2007-01-30",
     "dateOpen": "1996-01-01",
-    "description": "DirectSound3D was an extension to DirectX to standardize real-time 3D audio, allowing games to use a single API instead of coding for each sound card manufacturer. Its deprecation in Windows Vista decimated the game audio industry (see Creative, Auzentech).",
+    "description": "DirectSound3D was an extension to DirectSound to standardize real-time 3D audio, allowing games to use a single API instead of coding for each sound card manufacturer.",
     "link": "https://en.wikipedia.org/wiki/DirectSound",
+    "links": [
+      "https://techreport.com/review/13874/remixed-audio-cards-in-windows-vista/"
+    ],
     "name": "DirectSound3D",
     "type": "service"
   }

--- a/graveyard.json
+++ b/graveyard.json
@@ -592,5 +592,13 @@
     "link": "https://en.wikipedia.org/wiki/Microsoft_Response_Point",
     "name": "Response Point",
     "type": "software"
+  },
+  {
+    "dateClose": "2007-01-30",
+    "dateOpen": "1996-01-01",
+    "description": "DirectSound3D was an extension to DirectX to standardize real-time 3D audio, allowing games to use a single API instead of coding for each sound card manufacturer. Its deprecation in Windows Vista decimated the game audio industry (see Creative, Auzentech).",
+    "link": "https://en.wikipedia.org/wiki/DirectSound",
+    "name": "DirectSound3D",
+    "type": "service"
   }
 ]


### PR DESCRIPTION
For your consideration, the sad, unsung tale of the murder of DirectSound3D, and the subsequent starvation of the game audio industry, Creative SoundBlaster, EAX, Auzentech, Dolby Digital Live, et al. 

https://techreport.com/review/13874/remixed-audio-cards-in-windows-vista/