### PR TITLE
add Creative Writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ typings/
 
 # Build Files
 public/
+
+# Visual Studio Files
+/.vs

--- a/graveyard.json
+++ b/graveyard.json
@@ -592,5 +592,17 @@
     "link": "https://en.wikipedia.org/wiki/Microsoft_Response_Point",
     "name": "Response Point",
     "type": "software"
+  },
+  {
+    "dateClose": "1997-01-01",
+    "dateOpen": "1993-12-07",
+    "description": "Creative Writer was a word processor designed for children.",
+    "link": "https://en.wikipedia.org/wiki/Creative_Writer",
+    "links": [
+      "https://en.wikipedia.org/wiki/Creative_Writer",
+      "https://en.wikipedia.org/wiki/Creative_Writer_2"
+    ],
+    "name": "Creative Writer",
+    "type": "software"
   }
 ]

--- a/graveyard.json
+++ b/graveyard.json
@@ -594,7 +594,7 @@
     "description": "Response Point was an advanced VoIP-based telephone system targeting small businesses.",
     "link": "https://en.wikipedia.org/wiki/Microsoft_Response_Point",
     "name": "Response Point",
-    "type": "software"
+    "type": "service"
   },
   {
     "dateClose": "1997-01-01",
@@ -606,7 +606,7 @@
       "https://en.wikipedia.org/wiki/Creative_Writer_2"
     ],
     "name": "Creative Writer",
-    "type": "software"
+    "type": "app"
   },
   {
     "dateClose": "2008-04-21",

--- a/graveyard.json
+++ b/graveyard.json
@@ -607,7 +607,6 @@
     ],
     "name": "Creative Writer",
     "type": "software"
-    "type": "service"
   },
   {
     "dateClose": "2008-04-21",

--- a/graveyard.json
+++ b/graveyard.json
@@ -602,7 +602,6 @@
     "description": "Creative Writer was a word processor designed for children.",
     "link": "https://en.wikipedia.org/wiki/Creative_Writer",
     "links": [
-      "https://en.wikipedia.org/wiki/Creative_Writer",
       "https://en.wikipedia.org/wiki/Creative_Writer_2"
     ],
     "name": "Creative Writer",


### PR DESCRIPTION
Add Creative Writer, a word processor designed for children published by the Microsoft Kids group, to the graveyard.

I don't know the exact date of its demise. The dateClose value represents the year of the final release of Creative Writer 2 (marketed as a "sequel", but really just the subsequent version of the original), using Jan 1 as the placeholder for the month and day.

This PR includes update to .gitignore to ignore Visual Studio user-specific files.