### PR TITLE
docs: add PhotoDraw 2000 name.

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -229,7 +229,7 @@
   {
     "dateClose": "2004-06-30",
     "dateOpen": "1999-01-01",
-    "description": "Microsoft was a vector graphics and raster imaging software.",
+    "description": "Microsoft PhotoDraw 2000 was a vector graphics and raster imaging software.",
     "link": "https://en.wikipedia.org/wiki/Microsoft_PhotoDraw",
     "name": "Microsoft PhotoDraw 2000",
     "type": "app"


### PR DESCRIPTION
Microsoft PhotoDraw 2000's description was "Killed over 19 years ago, Microsoft (there should be product name) was a vector graphics and raster imaging software. It was over 5 years old."

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
