### PR TITLE
use desktop wikipedia link instead of mobile link

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1566,7 +1566,7 @@
     "dateClose": "2024-11-15",
     "dateOpen": "2008-01-01",
     "description": "TakeLessons was a platform for freelance teachers to connect with students.",
-    "link": "https://en.m.wikipedia.org/wiki/TakeLessons",
+    "link": "https://en.wikipedia.org/wiki/TakeLessons",
     "links": [
       "https://learn.microsoft.com/en-us/takelessons/takelessons-closure-faq",
       "https://www.crunchbase.com/organization/takelessons-com"


### PR DESCRIPTION
I just replaced the Wikipedia link for TakeLessons to use the desktop site like all of the other Wikipedia links instead of the mobile site.