### PR TITLE
Fix typos and improve Markdown formatting

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,9 @@
+# Killed by Microsoft
+
 <div align="center">
   <img src="../src/assets/tombstone.png" alt="tombstone" style="height: 80px; width: 80px; padding: 0 20px;">
-  <h1>Killed by Google</h1>
-  <p>A tribute and log of beloved products and services killed by Google.</p>
+  <h1>Killed by Microsoft</h1>
+  <p>A tribute and log of beloved products and services killed by Microsoft.</p>
 </div>
 
 ## Contributing Guide
@@ -11,10 +13,13 @@
 If you are contributing any code outside of `graveyard.json`, please ensure that your Pull Request will pass continuous integration. Run `yarn test` before opening your pull request which will check the React/Jest tests as well as verify that `graveyard.json` is formatted correctly _and_ well-formed. These tests are extremely important to quickly merging pull requests for this project.
 
 #### Continuous Integration (CI)
-Killed by Google uses [GitHub Actions](https://github.com/features/actions) for continuous integration testing. Every pull request and push must pass all checks before it can be merged into the `master` branch.
+
+Killed by Microsoft uses [GitHub Actions](https://github.com/features/actions) for continuous integration testing. Every pull request and push must pass all checks before it can be merged into the `master` branch.
 
 #### Continuous Delivery (CD)
-Killed by Google uses [Netlify](https://netlify.com) for hosting and continuous delivery. Netlify provides a publicly available deploy preview of your Pull Request and will build a new preview upon each push/update to your PR. The deploy preview will be evaluated manually by a maintainer before your PR is merged.
+
+Killed by Microsoft uses [Netlify](https://netlify.com) for hosting and continuous delivery. Netlify provides a publicly available deploy preview of your Pull Request and will build a new preview upon each push/update to your PR. The deploy preview will be evaluated manually by a maintainer before your PR is merged.
 
 ### Dependency Upgrades
-Killed by Google uses [Dependabot](https://dependabot.com/) for keeping dependencies up to date. Generally, a maintainer will wrap any upgrades issued by Dependabot in the `upgrades` branch, merge, and automatically close any Dependabot PRs. Any dependency upgrades must also pass CI and CD checks.
+
+Killed by Microsoft uses [Dependabot](https://dependabot.com/) for keeping dependencies up to date. Generally, a maintainer will wrap any upgrades issued by Dependabot in the `upgrades` branch, merge, and automatically close any Dependabot PRs. Any dependency upgrades must also pass CI and CD checks.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ If you are not familiar with or do not want to use `git`, submit a [new issue](h
   }
 ```
 
-1. Finally, [create a Pull Request (PR)](https://help.github.com/en/articles/creating-a-pull-request) using the newly created branch (Important: DON'T use the `master` branch for the PR). Submit it with the necessary explanations.  
+``ignore``
+5. Finally, [create a Pull Request (PR)](https://help.github.com/en/articles/creating-a-pull-request) using the newly created branch (Important: DON'T use the `master` branch for the PR). Submit it with the necessary explanations.  
 
 For code contributions outside of `graveyard.json`, check out the [Contributing Guide](.github/CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Killed by Microsoft
+
 <div align="center">
   <img src="src/assets/tombstone.png" alt="tombstone" style="height: 80px; width: 80px; padding: 0 20px;">
   <h1>Killed by Microsoft</h1>
@@ -15,7 +17,7 @@
 To add a product, gather the following information:
 
 - Name of Product (`name`) — the name of the product
-- Launch Date (`dateOpen`) — it should be the date of first release or at least the "beta" or when it is made avaialbe to the customer, do not confuse with the product's announcement
+- Launch Date (`dateOpen`) — it should be the date of first release or at least the "beta" or when it is made available to the customer, do not confuse with the product's announcement
 - Discontinued Date (`dateClose`) — it should be the date when the product is "no longer available for purchase" or, for web-based services, when the service stops its normal functioning. However, if it is not clear when an application was discontinued, you can use the date of the latest significant release (i.e., a release adding new features). This case is typical for old desktop applications.
 - Description (`description`) — a brief description of the product
 - Link (`link`) — relevant link to the source
@@ -63,7 +65,7 @@ If you are not familiar with or do not want to use `git`, submit a [new issue](h
   }
 ```
 
-5. Finally, [create a Pull Request (PR)](https://help.github.com/en/articles/creating-a-pull-request) using the newly created branch (Important: DON'T use the `master` branch for the PR). Submit it with the necessary explanations.  
+1. Finally, [create a Pull Request (PR)](https://help.github.com/en/articles/creating-a-pull-request) using the newly created branch (Important: DON'T use the `master` branch for the PR). Submit it with the necessary explanations.  
 
 For code contributions outside of `graveyard.json`, check out the [Contributing Guide](.github/CONTRIBUTING.md).
 
@@ -71,22 +73,28 @@ For code contributions outside of `graveyard.json`, check out the [Contributing 
 
 Install Node v14.x.x (😢):
 
+```bash
     yarn install
     node bin/graveyard
     yarn dev
+```
 
 The script in bin/graveyard.js updates graveyard.json and copy it in proper directory.
 Jest is used to test the project and in particular to test the format of graveyard.json. To run it type:
 
+```bash
     yarn jest
+```
 
 Then, to create the production version:
 
+```bash
     yarn build
+```
 
 ## Acknowledgements
 
-Thanks to Cody Odgen, author and designer of the graveyard for the products [killed by Google](https://github.com/codyogden/killedbygoogle), that provides the skeleton for *Killed by Microsoft*.
+Thanks to Cody Ogden, author and designer of the graveyard for the products [killed by Google](https://github.com/codyogden/killedbygoogle), that provides the skeleton for *Killed by Microsoft*.
 
 ## Notes
 

--- a/graveyard.json
+++ b/graveyard.json
@@ -519,7 +519,7 @@
   {
     "dateClose": "2013-04-08",
     "dateOpen": "2003-08-19",
-    "description": "Microsoft Office Picture Manager (formely Microsoft Picture Library) was a raster graphics editor included up to Office 2010 to organize and edit images.",
+    "description": "Microsoft Office Picture Manager (formerly Microsoft Picture Library) was a raster graphics editor included up to Office 2010 to organize and edit images.",
     "link": "https://en.wikipedia.org/wiki/Microsoft_Office_Picture_Manager",
     "name": "Microsoft Office Picture Manager",
     "type": "app"
@@ -870,7 +870,7 @@
   {
     "dateClose": "2013-02-13",
     "dateOpen": "2010-09-30",
-    "description": "Windows Live Mesh (formerly known as Windows Live FolderShare, Live Mesh, and Windows Live Sync) was a file synchronization application supporting both direct PC-to-PC and cloud-based synchronizazion and featuring Remote Desktop capability through the browser.",
+    "description": "Windows Live Mesh (formerly known as Windows Live FolderShare, Live Mesh, and Windows Live Sync) was a file synchronization application supporting both direct PC-to-PC and cloud-based synchronization and featuring Remote Desktop capability through the browser.",
     "link": "https://en.wikipedia.org/wiki/Windows_Live_Mesh",
     "name": "Windows Live Mesh",
     "type": "app"


### PR DESCRIPTION
This pull request updates the project's branding and documentation to consistently reference "Killed by Microsoft" instead of "Killed by Google." It also fixes several typos and improves instructions in the documentation. Additionally, there are minor corrections to product descriptions in `graveyard.json`.

Branding and documentation updates:

* Updated `.github/CONTRIBUTING.md` and `README.md` to replace all references to "Killed by Google" with "Killed by Microsoft," including section headings and explanatory text. [[1]](diffhunk://#diff-98e64bc1cd2db9333c6effe87bbe0d6dfe8714aba4c6bde45aa037fe0796e44cR1-R6) [[2]](diffhunk://#diff-98e64bc1cd2db9333c6effe87bbe0d6dfe8714aba4c6bde45aa037fe0796e44cL14-R25) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R2)

Documentation improvements and typo fixes:

* Fixed typos in `README.md`, such as correcting "avaialbe" to "available" and "Cody Odgen" to "Cody Ogden." Improved formatting of install and build instructions by adding code block markers. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R97)
* Corrected spelling errors in product descriptions within `graveyard.json` (e.g., "formely" to "formerly" and "synchronizazion" to "synchronization"). [[1]](diffhunk://#diff-fbf4a0c8746ccc097804715fc2b4e66fa9ff304543d51bc4eef3cb32b286a949L522-R522) [[2]](diffhunk://#diff-fbf4a0c8746ccc097804715fc2b4e66fa9ff304543d51bc4eef3cb32b286a949L873-R873)

This commit message was generated with Copilot.